### PR TITLE
Revert back to communityTopic subtype for Ready2021 session tags

### DIFF
--- a/resource/ready2021-prod/sidebarMetadata.json
+++ b/resource/ready2021-prod/sidebarMetadata.json
@@ -27,7 +27,7 @@
         "title": "translate.session.tag.connectionzonetopic",
         "layout": "link",
         "listings": "filters",
-        "subtype": "connectionZoneTopic",
+        "subtype": "communityTopic",
         "subMetadata": []
       },
       {

--- a/resource/ready2021-test/sidebarMetadata.json
+++ b/resource/ready2021-test/sidebarMetadata.json
@@ -27,7 +27,7 @@
         "title": "translate.session.tag.connectionzonetopic",
         "layout": "link",
         "listings": "filters",
-        "subtype": "connectionZoneTopic",
+        "subtype": "communityTopic",
         "subMetadata": []
       },
       {


### PR DESCRIPTION
Reverting back since we cant reliably use connectionZoneTopic due to the rest of the events and the frontend using communityTopic