### PR TITLE
IgniteNov2021 - update titles to translation strings, update 'solutionArea' prop to 'track'

### DIFF
--- a/resource/ignite2021nov-prod/sidebarMetadata.json
+++ b/resource/ignite2021nov-prod/sidebarMetadata.json
@@ -3,42 +3,42 @@
     "sidebarType": "session-tags",
     "metadata": [
       {
-        "title": "Session type",
+        "title": "translate.facet.session-type",
         "layout": "link",
         "listings": "filters",
         "subtype": "sessionType",
         "subMetadata": []
       },
       {
-        "title": "Level",
+        "title": "translate.facet.level",
         "layout": "link",
         "listings": "filters",
         "subtype": "level",
         "subMetadata": []
       },
       {
-        "title": "Solution Area",
+        "title": "translate.facet.track",
         "layout": "link",
         "listings": "filters",
-        "subtype": "solutionArea",
+        "subtype": "track",
         "subMetadata": []
       },
       {
-        "title": "Theme",
+        "title": "translate.facet.theme",
         "layout": "link",
         "listings": "filters",
         "subtype": "theme",
         "subMetadata": []
       },
       {
-        "title": "Connection Zone Topic",
+        "title": "translate.facet.connection-zone-topic",
         "layout": "link",
         "listings": "filters",
         "subtype": "communityTopic",
         "subMetadata": []
       },
       {
-        "title": "Learning Zone Topic",
+        "title": "translate.facet.platinum-club-topic",
         "layout": "link",
         "listings": "filters",
         "subtype": "learningZoneTopic",

--- a/resource/ignite2021nov-test/session_map.json
+++ b/resource/ignite2021nov-test/session_map.json
@@ -52,7 +52,7 @@
     },
     {
       "HubbId": 1019,
-      "SessionTypeName": "Technical Session",
+      "SessionTypeName": "Core Theme Session",
       "SessionSets": ["Session Catalog", "Session Scheduler", "My Schedule"]
     },
     {

--- a/resource/ignite2021nov-test/sidebarMetadata.json
+++ b/resource/ignite2021nov-test/sidebarMetadata.json
@@ -3,42 +3,42 @@
     "sidebarType": "session-tags",
     "metadata": [
       {
-        "title": "Session type",
+        "title": "translate.facet.session-type",
         "layout": "link",
         "listings": "filters",
         "subtype": "sessionType",
         "subMetadata": []
       },
       {
-        "title": "Level",
+        "title": "translate.facet.level",
         "layout": "link",
         "listings": "filters",
         "subtype": "level",
         "subMetadata": []
       },
       {
-        "title": "Solution Area",
+        "title": "translate.facet.track",
         "layout": "link",
         "listings": "filters",
-        "subtype": "solutionArea",
+        "subtype": "track",
         "subMetadata": []
       },
       {
-        "title": "Theme",
+        "title": "translate.facet.theme",
         "layout": "link",
         "listings": "filters",
         "subtype": "theme",
         "subMetadata": []
       },
       {
-        "title": "Connection Zone Topic",
+        "title": "translate.facet.connection-zone-topic",
         "layout": "link",
         "listings": "filters",
         "subtype": "communityTopic",
         "subMetadata": []
       },
       {
-        "title": "Learning Zone Topic",
+        "title": "translate.facet.platinum-club-topic",
         "layout": "link",
         "listings": "filters",
         "subtype": "learningZoneTopic",


### PR DESCRIPTION
One caveat - the translation string for Learning Zone in the DTO references the "translate.facet.platinum-club-topic". This change reflects that, but it is somewhat confusing. 